### PR TITLE
bugfix: updateVisibleItems accidentally being called with 'force'

### DIFF
--- a/src/components/VirtualScroller.vue
+++ b/src/components/VirtualScroller.vue
@@ -272,11 +272,11 @@ export default {
     },
 
     addWindowScroll () {
-      window.addEventListener('scroll', this.updateVisibleItems, true)
+      window.addEventListener('scroll', e => this.updateVisibleItems(), true)
     },
 
     removeWindowScroll () {
-      window.removeEventListener('scroll', this.updateVisibleItems, true)
+      window.removeEventListener('scroll', e => this.updateVisibleItems(), true)
     },
   },
 

--- a/src/components/VirtualScroller.vue
+++ b/src/components/VirtualScroller.vue
@@ -272,11 +272,11 @@ export default {
     },
 
     addWindowScroll () {
-      window.addEventListener('scroll', e => this.updateVisibleItems(), true)
+      window.addEventListener('scroll', () => this.updateVisibleItems(), true)
     },
 
     removeWindowScroll () {
-      window.removeEventListener('scroll', e => this.updateVisibleItems(), true)
+      window.removeEventListener('scroll', () => this.updateVisibleItems(), true)
     },
   },
 


### PR DESCRIPTION
window event was getting passed to updateVisibleItems(), which treated it as force = true