### PR TITLE
Fix for invisible elements

### DIFF
--- a/src/components/VirtualScroller.vue
+++ b/src/components/VirtualScroller.vue
@@ -180,7 +180,7 @@ export default {
           const heights = this.heights
           let h
           let a = 0
-          let b = l
+          let b = l - 1
           let i = ~~(l / 2)
           let oldI
 


### PR DESCRIPTION
When using virtual scroller with variable height mode and two items, the
first item can become invisible. Please see fiddle:

http://jsfiddle.net/6r6eonhe/