### PR TITLE
use correct ES2015 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-export default from './dist/vue-virtual-scroller'
+export {default} from './dist/vue-virtual-scroller'
 export * from './dist/vue-virtual-scroller'
 import './dist/vue-virtual-scroller.css'


### PR DESCRIPTION
`export default from '/file'` is invalid syntax and will not work in many parsers