### PR TITLE
Fix for containerHeight when clear items

### DIFF
--- a/src/components/VirtualScroller.vue
+++ b/src/components/VirtualScroller.vue
@@ -308,6 +308,9 @@ export default {
               // For containers style
               offsetTop = i > 0 ? heights[i - 1] : 0
               containerHeight = heights[l - 1]
+              if (containerHeight === undefined) {
+                containerHeight = 0
+              }
 
               // Searching for endIndex
               for (endIndex = i; endIndex < l && heights[endIndex] < scrollBottom; endIndex++);


### PR DESCRIPTION
In case of variable height mode, I removed all items, but the container height does not become 0.

![virtual_scroller_test](https://user-images.githubusercontent.com/1174500/33524017-f39fe8ba-d857-11e7-91cc-2fe2d3315771.png)
:arrow_down:
![virtual_scroller_test](https://user-images.githubusercontent.com/1174500/33524109-c7c17dba-d859-11e7-95eb-63e915173de3.png)
