### PR TITLE
fix: considearing before content slot height

### DIFF
--- a/src/components/VirtualScroller.vue
+++ b/src/components/VirtualScroller.vue
@@ -16,9 +16,11 @@
       :style="itemContainerStyle"
       class="item-container"
     >
-      <slot
-        name="before-content"
-      />
+      <div ref="beforeContentContainer">
+        <slot
+          name="before-content"
+        />
+      </div>
       <component
         ref="items"
         :is="contentTag"
@@ -253,6 +255,9 @@ export default {
             ) {
               this.keysEnabled = !(startIndex > this.$_endIndex || endIndex < this.$_startIndex)
 
+              if (this.$refs.beforeContentContainer.childElementCount) {
+                containerHeight = containerHeight + this.$refs.beforeContentContainer.clientHeight
+              }
               this.itemContainerStyle = {
                 height: containerHeight + 'px',
               }


### PR DESCRIPTION
The left images are with the current version of VirtualScroller component and the right are with the fix.

![fixed-before-container](https://user-images.githubusercontent.com/17838534/43047778-1e7e9e62-8db3-11e8-8de0-701df266bb80.jpg)
