### PR TITLE
Fixed Full Page Scrolling

### DIFF
--- a/src/mixins/scroller.js
+++ b/src/mixins/scroller.js
@@ -86,7 +86,7 @@ export default {
   methods: {
     getListenerTarget () {
       let target = ScrollParent(this.$el)
-      if (target === window.document.documentElement) {
+      if (target === window.document.body) {
         target = window
       }
       return target


### PR DESCRIPTION
In full-page mode with slotted components, the body scroll event listener was never firing and the list would never rerender. 

I debugged it back to the GetListenerTarget method and it was applying a scroll listener to "body" which doesn't work. 

This should also resolve #73. 