### PR TITLE
The default target for IOS should be body

### DIFF
--- a/src/mixins/scroller.js
+++ b/src/mixins/scroller.js
@@ -86,7 +86,7 @@ export default {
   methods: {
     getListenerTarget () {
       let target = ScrollParent(this.$el)
-      if (target === window.document.documentElement) {
+      if (target === window.document.documentElement || target === window.document.body) {
         target = window
       }
       return target


### PR DESCRIPTION
this component cannot work well in ios device with page-mode
because of the default scroller is not pointed to window