### PR TITLE
Add styles for kinetic scrolling on touch device in docs demo

### DIFF
--- a/docs-src/src/App.vue
+++ b/docs-src/src/App.vue
@@ -75,6 +75,10 @@ body {
   background: #42b983;
 }
 
+.vue-recycle-scroller {
+  -webkit-overflow-scrolling: touch;
+}
+
 .vue-recycle-scroller__item-container,
 .vue-recycle-scroller__item-wrapper {
   box-sizing: border-box;


### PR DESCRIPTION
When i tried the demo on an iPad the scroll in `.vue-recycle-scroller` wasn't "kinetic". So I added a line of CSS to fix the demo.