### PR TITLE
fix: avoid infinite loop on scrollToBottom with unknown sized elements

### DIFF
--- a/docs-src/src/components/TestChat.vue
+++ b/docs-src/src/components/TestChat.vue
@@ -53,7 +53,7 @@ export default {
       for (let i = 0; i < count; i++) {
         this.items.push({
           text: faker.lorem.lines(),
-          id: this.items.length + 1
+          id: this.items.length + 1,
         })
       }
       this.scrollToBottom()

--- a/docs-src/src/components/TestChat.vue
+++ b/docs-src/src/components/TestChat.vue
@@ -10,6 +10,9 @@
       <button @click="addItems(10)">
         Add 10 items
       </button>
+      <button @click="addItems(50)">
+        Add 50 items
+      </button>
     </div>
 
     <DynamicScroller
@@ -25,12 +28,7 @@
         :active="active"
         :data-index="index"
       >
-        <div
-          class="message"
-          :style="{
-            height: `${item.size}px`,
-          }"
-        >
+        <div class="message">
           {{ item.text }}
         </div>
       </DynamicScrollerItem>
@@ -54,9 +52,8 @@ export default {
     addItems (count = 1) {
       for (let i = 0; i < count; i++) {
         this.items.push({
-          text: faker.lorem.sentence(),
-          id: this.items.length + 1,
-          size: Math.random() * 120 + 40,
+          text: faker.lorem.lines(),
+          id: this.items.length + 1
         })
       }
       this.scrollToBottom()

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -149,7 +149,7 @@ export default {
     },
   },
 
-  created () {
+  beforeCreate () {
     this.$_updates = []
     this.$_undefinedSizes = 0
     this.$_undefinedMap = {}

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -123,6 +123,30 @@ export default {
     direction (value) {
       this.forceUpdate(true)
     },
+
+    itemsWithSize (next, prev) {
+      const scrollTop = this.$el.scrollTop
+
+      // Calculate total diff between prev and next sizes
+      // over current scroll top. Then add it to scrollTop to
+      // avoid jumping the contents that the user is seeing.
+      let prevActiveTop = 0; let activeTop = 0
+      const length = Math.min(next.length, prev.length)
+      for (let i = 0; i < length; i++) {
+        if (prevActiveTop >= scrollTop) {
+          break
+        }
+        prevActiveTop += prev[i].size || this.minItemSize
+        activeTop += next[i].size || this.minItemSize
+      }
+      const offset = activeTop - prevActiveTop
+
+      if (offset === 0) {
+        return
+      }
+
+      this.$el.scrollTop = this.$el.scrollTop + offset
+    },
   },
 
   created () {

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -178,11 +178,19 @@ export default {
       this.$nextTick(() => {
         // Item sizes are computed
         const cb = () => {
+          const prevTop = el.scrollTop
           el.scrollTop = el.scrollHeight
-          if (this.$_undefinedSizes === 0) {
+
+          // If scroll top is not changed, that means the scroll position is
+          // already bottom and stable. We stop the process of scrolling to bottom here.
+          if (prevTop === el.scrollTop) {
             this.$_scrollingToBottom = false
           } else {
-            requestAnimationFrame(cb)
+            // Wait for RecycleScroller's visible items calculation
+            requestAnimationFrame(() => {
+              // Wait for DOM update
+              requestAnimationFrame(cb)
+            })
           }
         }
         requestAnimationFrame(cb)


### PR DESCRIPTION
fix #221 

I've changed the termination condition to when the scrollTop value is not changed since the previous update.

Also added `requestAnimationFrame` during the loop because we need to wait [delayed processing in `RecycleView` after triggering `scroll` event](https://github.com/Akryum/vue-virtual-scroller/blob/master/src/components/RecycleScroller.vue#L241) and DOM update.

To check the behavior the scroll to bottom example has been updated not to specify fixed size for each item.