### PR TITLE
chore: exclude vue for es module bundle

### DIFF
--- a/build/rollup.config.es.js
+++ b/build/rollup.config.es.js
@@ -7,6 +7,7 @@ const config = Object.assign({}, base, {
     format: 'es',
   },
   external: [
+    'vue',
     'scrollparent',
     'vue-observe-visibility',
     'vue-resize',


### PR DESCRIPTION
Since `Object.assign` does not merge nested array, the `external` option in `rollup.config.es.js` does not include `vue`. Then the ES module bundle includes Vue code which seems not intended behavior.