### PR TITLE
Fix misleading CSS file import instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import { RecycleScroller } from 'vue-virtual-scroller'
 Vue.component('RecycleScroller', RecycleScroller)
 ```
 
-**⚠️ A css file is included when importing the package:**
+**⚠️ The line below should be included when importing the package:**
 
 ```js
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'


### PR DESCRIPTION
The CSS file is not imported by default, so the doc should read "should be included", not "is included".