### PR TITLE
feat: throw error when key field does not exist in item

### DIFF
--- a/src/components/DynamicScrollerItem.vue
+++ b/src/components/DynamicScrollerItem.vue
@@ -45,7 +45,9 @@ export default {
 
   computed: {
     id () {
-      return this.vscrollData.simpleArray ? this.index : this.item[this.vscrollData.keyField]
+      if (this.vscrollData.simpleArray) return this.index;
+      if (this.item.hasOwnProperty(this.vscrollData.keyField)) return this.item[this.vscrollData.keyField];
+      throw new Error(`keyField '${this.vscrollData.keyField}' not found in your item. You should set a valid keyField prop on your Scroller`);
     },
 
     size () {


### PR DESCRIPTION
Hello !

I just had a hard time understanding what was happening because I set badly the `key-field` prop on the DynamicScroller.

I propose this change so that the component fails faster with a clearer error, does this feel right to you ?

Thanks !