### PR TITLE
Small refactoring and fix

### DIFF
--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -441,22 +441,21 @@ export default {
               view = this.addView(pool, i, item, key, type)
             }
           } else {
-            v = unusedIndex.get(type) || 0
-            // Use existing view
-            // We don't care if they are already used
-            // because we are not in continous scrolling
-            if (unusedPool && v < unusedPool.length) {
-              view = unusedPool[v]
-              view.item = item
-              view.nr.used = true
-              view.nr.index = i
-              view.nr.key = key
-              view.nr.type = type
-              unusedIndex.set(type, v + 1)
-            } else {
+            if (!unusedPool || v >= unusedPool.length) {
               view = this.addView(pool, i, item, key, type)
               this.unuseView(view, true)
             }
+            // Use existing view
+            // We don't care if they are already used
+            // because we are not in continous scrolling
+            v = unusedIndex.get(type) || 0
+            view = unusedPool[v]
+            view.item = item
+            view.nr.used = true
+            view.nr.index = i
+            view.nr.key = key
+            view.nr.type = type
+            unusedIndex.set(type, v + 1)
             v++
           }
           views.set(key, view)

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -372,7 +372,6 @@ export default {
       let view
 
       const continuous = startIndex <= this.$_endIndex && endIndex >= this.$_startIndex
-      let unusedIndex
 
       if (this.$_continuous !== continuous) {
         if (continuous) {
@@ -407,9 +406,7 @@ export default {
         }
       }
 
-      if (!continuous) {
-        unusedIndex = new Map()
-      }
+      let unusedIndex = continuous ? null : new Map();
 
       let item, type, unusedPool
       let v

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -426,9 +426,9 @@ export default {
         // No view assigned to item
         if (!view) {
           type = item[typeField]
+          unusedPool = unusedViews.get(type)
 
           if (continuous) {
-            unusedPool = unusedViews.get(type)
             // Reuse existing view
             if (unusedPool && unusedPool.length) {
               view = unusedPool.pop()
@@ -441,7 +441,6 @@ export default {
               view = this.addView(pool, i, item, key, type)
             }
           } else {
-            unusedPool = unusedViews.get(type)
             v = unusedIndex.get(type) || 0
             // Use existing view
             // We don't care if they are already used


### PR DESCRIPTION
I'm still researching this. So far I've seen that `updateVisibleItems` is called multiple times on initial load which helps it to hide this issue.

When `updateVisibleItems` is called first time it has a bug. For first item it doesn't have available views in a pool, so it creates new unused view, for second item it gets view and adjust it to second item. Third item again doesn't have available view in the pool etc...
![image](https://user-images.githubusercontent.com/3540487/79348000-aa469200-7f34-11ea-9b09-c08093e7b9ca.png)


When `updateVisibleItems` is called second time everything is fine. Usually you don't see anything between calls because they are fast. In our case items render time is slow so you can clearly see this bug.
![image](https://user-images.githubusercontent.com/3540487/79348068-c5b19d00-7f34-11ea-994f-2471fb21f383.png)

Basically this will create unused view and then assign item to it. This is probably fixing #368 

Also in the process I did small refactoring.

What do you think, am I understanding this correctly? Sorry for ugly images.