### PR TITLE
fix: Avoid updatingVisibleItems loop

### DIFF
--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -252,11 +252,11 @@ export default {
         this.$_scrollDirty = true
         requestAnimationFrame(() => {
           this.$_scrollDirty = false
-          const { continuous } = this.updateVisibleItems(false, true)
+          const { continuous, checkPositionDiff } = this.updateVisibleItems(false, true)
 
           // It seems sometimes chrome doesn't fire scroll event :/
           // When non continous scrolling is ending, we force a refresh
-          if (!continuous) {
+          if (!continuous && !checkPositionDiff) {
             clearTimeout(this.$_refreshTimout)
             this.$_refreshTimout = setTimeout(this.handleScroll, 100)
           }
@@ -307,6 +307,7 @@ export default {
           if ((itemSize === null && positionDiff < minItemSize) || positionDiff < itemSize) {
             return {
               continuous: false,
+              checkPositionDiff
             }
           }
         }

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -252,11 +252,11 @@ export default {
         this.$_scrollDirty = true
         requestAnimationFrame(() => {
           this.$_scrollDirty = false
-          const { continuous, checkPositionDiff } = this.updateVisibleItems(false, true)
+          const { continuous } = this.updateVisibleItems(false, true)
 
           // It seems sometimes chrome doesn't fire scroll event :/
           // When non continous scrolling is ending, we force a refresh
-          if (!continuous && !checkPositionDiff) {
+          if (!continuous) {
             clearTimeout(this.$_refreshTimout)
             this.$_refreshTimout = setTimeout(this.handleScroll, 100)
           }
@@ -306,8 +306,7 @@ export default {
           if (positionDiff < 0) positionDiff = -positionDiff
           if ((itemSize === null && positionDiff < minItemSize) || positionDiff < itemSize) {
             return {
-              continuous: false,
-              checkPositionDiff
+              continuous: true,
             }
           }
         }


### PR DESCRIPTION
`handleScroll` is checking for position diff `checkPositionDiff` and returning `{ continuous: false }` which causes handleScroll to recheck again and again. This way, handleScroll is allowed only once to trigger `updateVisibleItems`.

Also, question, I guess `this.$_scrollDirty` is used to prevent queuing multiple requests for animation frame. Would better option be to assign return from `requestAnimationFrame` to a variable and before it do a `cancelAnimationFrame`. That way only one, the latest request, will be triggered.