### PR TITLE
Add buffer to dynamic scroller. Closes #278

### DIFF
--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -9,6 +9,7 @@
     @resize="onScrollerResize"
     @visible="onScrollerVisible"
     v-on="listeners"
+    :buffer="buffer"
   >
     <template slot-scope="{ item: itemWithSize, index, active }">
       <slot
@@ -74,6 +75,11 @@ export default {
     minItemSize: {
       type: [Number, String],
       required: true,
+    },
+
+    buffer: {
+      type: Number,
+      default: 200,
     },
   },
 

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -4,12 +4,12 @@
     :items="itemsWithSize"
     :min-item-size="minItemSize"
     :direction="direction"
+    :buffer="buffer"
     key-field="id"
     v-bind="$attrs"
     @resize="onScrollerResize"
     @visible="onScrollerVisible"
     v-on="listeners"
-    :buffer="buffer"
   >
     <template slot-scope="{ item: itemWithSize, index, active }">
       <slot


### PR DESCRIPTION
There is no buffer property for the `DynamicScroller`. This PR fixes this.

Relates to https://github.com/Akryum/vue-virtual-scroller/issues/278