### PR TITLE
Allow mouseenter/mouseleave events to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ When the user scrolls inside RecycleScroller, the views are mostly just moved ar
 - `prerender` (default: `0`): render a fixed number of items for Server-Side Rendering (SSR).
 - `buffer` (default: `200`): amount of pixel to add to edges of the scrolling visible area to start rendering items further away.
 - `emitUpdate` (default: `false`): emit a `'update'` event each time the virtual scroller content is updated (can impact performance).
+- `detectHover` (default: `true`): whether listen for `'mouseenter'` and `'mouseleave'` events and apply the `hover` class as a result
 
 ### Events
 

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -29,8 +29,7 @@
         :style="ready ? { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
         class="vue-recycle-scroller__item-view"
         :class="{ hover: hoverKey === view.nr.key }"
-        @mouseenter="hoverKey = view.nr.key"
-        @mouseleave="hoverKey = null"
+        v-on="detectHover ? { mouseenter: () => hoverKey = view.nr.key, mouseleave: () => hoverKey = null } : {}"
       >
         <slot
           :item="view.item"
@@ -115,6 +114,11 @@ export default {
     emitUpdate: {
       type: Boolean,
       default: false,
+    },
+
+    detectHover: {
+      type: Boolean,
+      default: true,
     },
   },
 


### PR DESCRIPTION
The `mouseenter` and `mouseleave` event listeners have shown some performance issues, and there's some demand for them to be toggleable as a result. This PR adds a prop for disabling these events.

There's no breaking changes – if you don't use the prop, nothing will change.

Usage:
```html
<RecycleScroller :detectHover="false" />
```

This resolves #178