### PR TITLE
Disable RENDER_FUNCTION to to work with vue compat

### DIFF
--- a/packages/vue-virtual-scroller/src/components/DynamicScrollerItem.vue
+++ b/packages/vue-virtual-scroller/src/components/DynamicScrollerItem.vue
@@ -2,6 +2,10 @@
 import { h } from 'vue'
 
 export default {
+  compatConfig: {
+    RENDER_FUNCTION: false
+  },
+
   name: 'DynamicScrollerItem',
 
   inject: [

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -28,7 +28,12 @@
         :key="view.nr.id"
         :style="ready ? { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
         class="vue-recycle-scroller__item-view"
-        :class="{ hover: hoverKey === view.nr.key }"
+        :class="[
+          itemClass,
+          {
+            hover: hoverKey === view.nr.key
+          },
+        ]"
         @mouseenter="hoverKey = view.nr.key"
         @mouseleave="hoverKey = null"
       >
@@ -116,6 +121,11 @@ export default {
     emitUpdate: {
       type: Boolean,
       default: false,
+    },
+
+    itemClass: {
+      type: [String, Object, Array],
+      default: '',
     },
   },
 

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -162,10 +162,18 @@ export default {
       return []
     },
 
+    itemsSize() {
+      return this.items.length
+    },
+
     simpleArray,
   },
 
   watch: {
+    itemsSize () {
+      this.updateVisibleItems(true)
+    },
+
     items () {
       this.updateVisibleItems(true)
     },


### PR DESCRIPTION
Hello!

We are using your package at Crisp and recently we started to migrate our project to Vue 3 using @vue/compat.

During the migration process, we discovered that DynamicScrollerItem is rendered using the compatibility renderer.

Disabling RENDER_FUNCTION  fixes the problem
