### PR TITLE
Use v-memo to prevent update of all rows when the hoverKey changes

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -26,6 +26,7 @@
       <div
         v-for="view of pool"
         :key="view.nr.id"
+        v-memo="[view.item, view.position, hoverKey === view.nr.key ]"
         :style="ready ? { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
         class="vue-recycle-scroller__item-view"
         :class="{ hover: hoverKey === view.nr.key }"


### PR DESCRIPTION
Whenever the hoverKey changes due to a mouse event all rows in the pool would be updated.
Using v-memo the update can be limited to only the affected rows.

It might be that the correct fix is something else since the before and after slots appear to be updated when hoverKey changes also.

