### PR TITLE
fix: view sorting in next

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -596,7 +596,7 @@ export default {
     },
 
     sortViews () {
-      this.pool.sort((viewA, viewB) => viewA.index - viewB.index)
+      this.pool.sort((viewA, viewB) => viewA.nr.index - viewB.nr.index)
     },
   },
 }


### PR DESCRIPTION
It looks like the code for view sorting was accidentally changed when creating the Vue3 version. Reverting this changes ensures the functionality works correctly.