### PR TITLE
fix: restore scroll in keep-alive

### DIFF
--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -204,9 +204,9 @@ export default {
   activated() {
     const lastPosition = this.$_lastUpdateScrollPosition;
     if (typeof lastPosition === 'number') {
-      setTimeout(() => {
+      this.$nextTick(() => {
         this.scrollToPosition(lastPosition);
-      }, 0)
+      });
     }
   },
 

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -201,6 +201,15 @@ export default {
     })
   },
 
+  activated() {
+    const lastPosition = this.$_lastUpdateScrollPosition;
+    if (typeof lastPosition === 'number') {
+      setTimeout(() => {
+        this.scrollToPosition(lastPosition);
+      }, 0)
+    }
+  },
+
   beforeDestroy () {
     this.removeListeners()
   },


### PR DESCRIPTION
when we use router-view and keep alive with RecycleScroller, if we change the router, then back, we will see the scroller position will change to the top. we need to keep the position