### PR TITLE
fix(RecycleScroller): Introduce an item wrapper to reduce re-render 

### DIFF
--- a/packages/vue-virtual-scroller/src/components/ItemView.vue
+++ b/packages/vue-virtual-scroller/src/components/ItemView.vue
@@ -1,0 +1,29 @@
+<template>
+  <component
+    :is="itemTag"
+    class="vue-recycle-scroller__item-view"
+    :class="{ hover }"
+    @mouseenter="hover = true"
+    @mouseleave="hover = false"
+  >
+    <slot
+      :item="view.item"
+      :index="view.nr.index"
+      :active="view.nr.used"
+    />
+  </component>
+</template>
+
+<script>
+export default {
+  props: {
+    view: Object,
+    itemTag: String,
+  },
+  data () {
+    return {
+      hover: false,
+    }
+  },
+}
+</script>

--- a/packages/vue-virtual-scroller/src/components/ItemView.vue
+++ b/packages/vue-virtual-scroller/src/components/ItemView.vue
@@ -1,10 +1,9 @@
+<!-- Avoir re-renders of slots -->
+
 <template>
   <component
     :is="itemTag"
     class="vue-recycle-scroller__item-view"
-    :class="{ hover }"
-    @mouseenter="hover = true"
-    @mouseleave="hover = false"
   >
     <slot
       :item="view.item"
@@ -19,11 +18,6 @@ export default {
   props: {
     view: Object,
     itemTag: String,
-  },
-  data () {
-    return {
-      hover: false,
-    }
   },
 }
 </script>

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -54,7 +54,11 @@
           mouseenter: () => { hoverKey = view.nr.key },
           mouseleave: () => { hoverKey = null },
         }"
-      />
+      >
+        <template #default="props">
+          <slot v-bind="props" />
+        </template>
+      </ItemView>
 
       <slot
         name="empty"
@@ -202,6 +206,9 @@ export default {
       pool: [],
       totalSize: 0,
       ready: false,
+      /**
+       * We need the key of the hovered item to prevent ItemView that gets recycled to keep the hover state.
+       */
       hoverKey: null,
     }
   },

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -30,6 +30,7 @@
         v-for="view of pool"
         ref="items"
         :key="view.nr.id"
+        :view="view"
         :item-tag="itemTag"
         :style="ready
           ? [
@@ -53,13 +54,7 @@
           mouseenter: () => { hoverKey = view.nr.key },
           mouseleave: () => { hoverKey = null },
         }"
-      >
-        <slot
-          :item="view.item"
-          :index="view.nr.index"
-          :active="view.nr.used"
-        />
-      </ItemView>
+      />
 
       <slot
         name="empty"

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -26,11 +26,11 @@
       class="vue-recycle-scroller__item-wrapper"
       :class="listClass"
     >
-      <component
-        :is="itemTag"
+      <ItemView
         v-for="view of pool"
         ref="items"
         :key="view.nr.id"
+        :item-tag="itemTag"
         :style="ready
           ? [
             (disableTransform
@@ -59,7 +59,7 @@
           :index="view.nr.index"
           :active="view.nr.used"
         />
-      </component>
+      </ItemView>
 
       <slot
         name="empty"
@@ -88,6 +88,7 @@ import { getScrollParent } from '../scrollparent'
 import config from '../config'
 import { props, simpleArray } from './common'
 import { supportsPassive } from '../utils'
+import ItemView from './ItemView.vue'
 
 let uid = 0
 
@@ -95,6 +96,7 @@ export default {
   name: 'RecycleScroller',
 
   components: {
+    ItemView,
     ResizeObserver,
   },
 


### PR DESCRIPTION
When rendering a slot, Vue will act as if the slot content was expanded
in-line at the `<slot>`'s place.

Having the slots in a v-for therefore can trigger too much rerender for the
slot content, and was generally bad for performance.

Wrapping them in a component should provide some performance improvements as
well as solving the hover update overhead.