### PR TITLE
fix: Rewrite view (re-)assignment logic

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -258,6 +258,14 @@ export default {
       }
     },
 
+    removeAndRecycleAllViews () {
+      this.$_views.clear()
+      this.$_recycledPools.clear()
+      for (let i = 0, l = this.pool.length; i < l; i++) {
+        this.removeAndRecycleView(this.pool[i])
+      }
+    },
+
     handleResize () {
       this.$emit('resize')
       if (this.ready) this.updateVisibleItems(false)
@@ -391,12 +399,7 @@ export default {
 
       if (this.$_continuous !== continuous) {
         if (continuous) {
-          views.clear()
-          unusedViews.clear()
-          for (let i = 0, l = pool.length; i < l; i++) {
-            view = pool[i]
-            this.removeAndRecycleView(view)
-          }
+          this.removeAndRecycleAllViews()
         }
         this.$_continuous = continuous
       } else if (continuous) {

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -231,6 +231,17 @@ export default {
       return view
     },
 
+    getRecycledView (type) {
+      const recycledPool = this.getRecycledPool(type)
+      if (recycledPool && recycledPool.length) {
+        const view = recycledPool.pop()
+        view.nr.used = true
+        return view
+      } else {
+        return null
+      }
+    },
+
     removeAndRecycleView (view, fake = false) {
       const unusedViews = this.$_unusedViews
       const type = view.nr.type
@@ -431,14 +442,12 @@ export default {
         // No view assigned to item
         if (!view) {
           type = item[typeField]
-          unusedPool = unusedViews.get(type)
+          view = this.getRecycledView(type)
 
           if (continuous) {
             // Reuse existing view
-            if (unusedPool && unusedPool.length) {
-              view = unusedPool.pop()
+            if (view) {
               view.item = item
-              view.nr.used = true
               view.nr.index = i
               view.nr.key = key
               view.nr.type = type

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -254,15 +254,13 @@ export default {
       }
     },
 
-    removeAndRecycleView (view, fake = false) {
+    removeAndRecycleView (view) {
       const type = view.nr.type
       const recycledPool = this.getRecycledPool(type)
       recycledPool.push(view)
-      if (!fake) {
-        view.nr.used = false
-        view.position = -9999
-        this.$_views.delete(view.nr.key)
-      }
+      view.nr.used = false
+      view.position = -9999
+      this.$_views.delete(view.nr.key)
     },
 
     removeAndRecycleAllViews () {

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -231,7 +231,7 @@ export default {
       return view
     },
 
-    unuseView (view, fake = false) {
+    removeAndRecycleView (view, fake = false) {
       const unusedViews = this.$_unusedViews
       const type = view.nr.type
       let unusedPool = unusedViews.get(type)
@@ -384,7 +384,7 @@ export default {
           unusedViews.clear()
           for (let i = 0, l = pool.length; i < l; i++) {
             view = pool[i]
-            this.unuseView(view)
+            this.removeAndRecycleView(view)
           }
         }
         this.$_continuous = continuous
@@ -405,7 +405,7 @@ export default {
               view.nr.index < startIndex ||
               view.nr.index >= endIndex
             ) {
-              this.unuseView(view)
+              this.removeAndRecycleView(view)
             }
           }
         }
@@ -424,7 +424,7 @@ export default {
         view = views.get(key)
 
         if (!itemSize && !sizes[i].size) {
-          if (view) this.unuseView(view)
+          if (view) this.removeAndRecycleView(view)
           continue
         }
 
@@ -453,7 +453,7 @@ export default {
 
             if (!unusedPool || v >= unusedPool.length) {
               view = this.createView(pool, i, item, key, type)
-              this.unuseView(view, true)
+              this.removeAndRecycleView(view, true)
               unusedPool = unusedViews.get(type)
             }
 

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -214,7 +214,7 @@ export default {
   },
 
   methods: {
-    addView (pool, index, item, key, type) {
+    createView (pool, index, item, key, type) {
       const nr = markRaw({
         id: uid++,
         index,
@@ -443,7 +443,7 @@ export default {
               view.nr.key = key
               view.nr.type = type
             } else {
-              view = this.addView(pool, i, item, key, type)
+              view = this.createView(pool, i, item, key, type)
             }
           } else {
             // Use existing view
@@ -452,7 +452,7 @@ export default {
             v = unusedIndex.get(type) || 0
 
             if (!unusedPool || v >= unusedPool.length) {
-              view = this.addView(pool, i, item, key, type)
+              view = this.createView(pool, i, item, key, type)
               this.unuseView(view, true)
               unusedPool = unusedViews.get(type)
             }

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -282,7 +282,7 @@ export default {
       }
     },
 
-    updateVisibleItems (checkItem, checkPositionDiff = false) {
+    updateVisibleItems (itemsChanged, checkPositionDiff = false) {
       const itemSize = this.itemSize
       const minItemSize = this.$_computedMinItemSize
       const typeField = this.typeField
@@ -393,7 +393,7 @@ export default {
           view = pool[i]
           if (view.nr.used) {
             // Update view item index
-            if (checkItem) {
+            if (itemsChanged) {
               view.nr.index = items.findIndex(
                 item => keyField ? item[keyField] === view.item[keyField] : item === view.item,
               )

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -458,7 +458,9 @@ export default {
               view.item = item
               view.nr.index = i
               view.nr.key = key
-              view.nr.type = type
+              if (view.nr.type !== type) {
+                console.warn("Reused view's type does not match pool's type")
+              }
             } else {
               view = this.createView(pool, i, item, key, type)
             }
@@ -485,8 +487,10 @@ export default {
           }
           views.set(key, view)
         } else {
-          view.nr.used = true
           view.item = item
+          if (!view.nr.used) {
+            console.warn("Expected existing view's used flag to be true, got " + view.nr.used)
+          }
         }
 
         // Update position

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -214,6 +214,16 @@ export default {
   },
 
   methods: {
+    getRecycledPool (type) {
+      const recycledPools = this.$_recycledPools
+      let recycledPool = recycledPools.get(type)
+      if (!recycledPool) {
+        recycledPool = []
+        recycledPools.set(type, recycledPool)
+      }
+      return recycledPool
+    },
+
     createView (pool, index, item, key, type) {
       const nr = markRaw({
         id: uid++,
@@ -243,14 +253,9 @@ export default {
     },
 
     removeAndRecycleView (view, fake = false) {
-      const unusedViews = this.$_unusedViews
       const type = view.nr.type
-      let unusedPool = unusedViews.get(type)
-      if (!unusedPool) {
-        unusedPool = []
-        unusedViews.set(type, unusedPool)
-      }
-      unusedPool.push(view)
+      const recycledPool = this.getRecycledPool(type)
+      recycledPool.push(view)
       if (!fake) {
         view.nr.used = false
         view.position = -9999


### PR DESCRIPTION
### Description (from primary commit)

This commit rewrites the view (re-)assignment logic in a way that is shorter
and therefore easier to read through. The performance is generally on par with
the old implementation. It also fixes bugs in the old logic where:
- The item itself getting used as the keyField instead of the index.
- Sometimes a view could get stuck in a corrupted state where its key doesn't
  match what the index or item indicates.

These bugs were rather hard to reason about in the old logic due to the
redundant code path it had (which weakened the invariants). The new logic
unifies paths for simplicity, while keeping the time complexity aspect roughly
the same.

### Testing

I've done some brief tests on this using my own app and it has been working fine, even better because there were some annoying bugs before as described above.

Not all code paths are exercised in my app though, so additional testing would be useful.

### Reviewing

This PR is split into a bunch of small refactoring commits that should be trivial to review, and a main commit (`fix(RecycleScroller): Rewrite view (re-)assignment logic`) after all the refactoring is done. It should be easier to review commit by commit.