### PR TITLE
fix: issue with beforeDestroy hook

### DIFF
--- a/src/components/DynamicScrollerItem.vue
+++ b/src/components/DynamicScrollerItem.vue
@@ -194,7 +194,7 @@ export default {
     },
 
     observeSize () {
-      if (!this.vscrollResizeObserver) return
+      if (!this.vscrollResizeObserver || !this.$el.parentNode) return
       this.vscrollResizeObserver.observe(this.$el.parentNode)
       this.$el.parentNode.addEventListener('resize', this.onResize)
     },


### PR DESCRIPTION
This fixes the issue when the dynamic scroller disappears out of view and the this.$el.parentNode returns nothing causing the observer to have issues, stack trace for current issue follows

 [Vue warn]: Error in beforeDestroy hook: "TypeError: Failed to execute 'unobserve' on 'ResizeObserver': parameter 1 is not of type 'Element'."
```
found in

---> <DynamicScrollerItem>
       <RecycleScroller>
         <DynamicScroller>
           <SeatSelect> at src/components/SeatSelectComponent.vue
             <Event> at src/views/Event.vue
               <App> at src/App.vue
                 <Root>
                 ```