### PR TITLE
fix(RecycleScroller): gridItems is undefined when scrollToItem, fix #773

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -680,10 +680,11 @@ export default {
 
     scrollToItem (index) {
       let scroll
+      const gridItems = this.gridItems || 1
       if (this.itemSize === null) {
         scroll = index > 0 ? this.sizes[index - 1].accumulator : 0
       } else {
-        scroll = Math.floor(index / this.gridItems) * this.itemSize
+        scroll = Math.floor(index / gridItems) * this.itemSize
       }
       this.scrollToPosition(scroll)
     },


### PR DESCRIPTION
**Description**
```
Fix RecycleScroller scrollToItem method when itemSize is not null.  
Scroll position is wrong because gridItems is undefined.
```

**Reproduction**
[Demo site](https://vue-virtual-scroller-demo.netlify.app/recycle)
```
1. unchecked 'variable height'
2. click 'Scroll To:' button
3. list scroll to 'item 0' (not 'item 100')
```