### PR TITLE
fix: avoid rendering when slot is unused

### DIFF
--- a/packages/vue-virtual-scroller/src/components/DynamicScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/DynamicScroller.vue
@@ -21,10 +21,16 @@
         }"
       />
     </template>
-    <template #before>
+    <template
+      v-if="$slots.before"
+      #before
+    >
       <slot name="before" />
     </template>
-    <template #after>
+    <template
+      v-if="$slots.after"
+      #after
+    >
       <slot name="after" />
     </template>
     <template #empty>


### PR DESCRIPTION
Currently, when using `<DynamicScroller>` it always render `<slot name="before" />` and `<slot name="after" />`. Maybe we can avoid rendering these two nodes when they are not actually used.