### PR TITLE
fix: scrollState value

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -636,7 +636,9 @@ export default {
         const boundsSize = isVertical ? bounds.height : bounds.width
         let start = -(isVertical ? bounds.top : bounds.left)
         let size = isVertical ? window.innerHeight : window.innerWidth
-        if (start < 0) {
+        let originStart = isVertical ? bounds.top : bounds.left;
+        // Fix start value when the el is scrolling from under the viewport to the middle of the viewport
+        if (start < 0 && !(originStart > 0 && originStart < size)) {
           size += start
           start = 0
         }


### PR DESCRIPTION
Description

Fix scrollState value;
In getScroll funtion, the start value will always be zero if start < 0, although the start is less than size(window.innerHeight if vertical), the problem is: 
if there's a virtual list below the viewport, then scroll the virtual list to the middle of the viewport, you will see there're blank rows(only rendered buffer items), because the start value is still zero, so positionDiff will be zero, then updateVisibleItems function will be return, blank rows appeared.
so i changed the condition, don't set start to zero if bounds.top(if vertical) is great than 0 and less than size, that means the scroll list is entering the viewport, need to recalculate the startIndex and endIndex, so that blank rows will be disappeared and render real items.

Reproduction
[Demo site](https://stackblitz.com/edit/vue-xcta2z?file=src%2Fcomponents%2FRecycleScrollerDemo.vue)

1. scroll the virtual list under the viewport to the middle of the viewport
2. you will see there're blank rows
