### PR TITLE
fix: template instead of div in slots before after 

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -9,15 +9,16 @@
     }"
     @scroll.passive="handleScroll"
   >
-    <template
+    <div
       v-if="$slots.before"
       ref="before"
       class="vue-recycle-scroller__slot"
+      :style="beforeStyle"
     >
       <slot
         name="before"
       />
-    </template>
+    </div>
 
     <component
       :is="listTag"
@@ -65,15 +66,16 @@
       />
     </component>
 
-    <template
+    <div
       v-if="$slots.after"
       ref="after"
       class="vue-recycle-scroller__slot"
+      :style="afterStyle"
     >
       <slot
         name="after"
       />
-    </template>
+    </div>
 
     <ResizeObserver @notify="handleResize" />
   </div>
@@ -190,6 +192,20 @@ export default {
       type: [String, Object, Array],
       default: '',
     },
+
+    beforeStyle:{
+      type: Object,
+      default: ()=>{
+
+      }
+    },
+
+    afterStyle:{
+      type: Object,
+      default: ()=>{
+        
+      }
+    }
   },
 
   emits: [

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -9,7 +9,7 @@
     }"
     @scroll.passive="handleScroll"
   >
-    <div
+    <template
       v-if="$slots.before"
       ref="before"
       class="vue-recycle-scroller__slot"
@@ -17,7 +17,7 @@
       <slot
         name="before"
       />
-    </div>
+    </template>
 
     <component
       :is="listTag"
@@ -65,7 +65,7 @@
       />
     </component>
 
-    <div
+    <template
       v-if="$slots.after"
       ref="after"
       class="vue-recycle-scroller__slot"
@@ -73,7 +73,7 @@
       <slot
         name="after"
       />
-    </div>
+    </template>
 
     <ResizeObserver @notify="handleResize" />
   </div>


### PR DESCRIPTION
When using vue-virtual-scroller as table and adding thead and tfoot tags extra div components are coming which are changing table structure 