### PR TITLE
fix(RecycleScroller): gridItems is undefined when scrollToItem, fix #773

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -673,10 +673,11 @@ export default {
 
     scrollToItem (index) {
       let scroll
+      const gridItems = this.gridItems || 1
       if (this.itemSize === null) {
         scroll = index > 0 ? this.sizes[index - 1].accumulator : 0
       } else {
-        scroll = Math.floor(index / this.gridItems) * this.itemSize
+        scroll = Math.floor(index / gridItems) * this.itemSize
       }
       this.scrollToPosition(scroll)
     },


### PR DESCRIPTION
This bug was fix ~16 months ago in v2, but also exists in v1. I realise Vue2 is now officially dead, but we're still some way off being able to jump to Vue3 and I'd really like to be able to update the virtual scroller. Thanks.