### PR TITLE
fix(empty gaps): prevent empty gaps on fast scrolling, fix (#863, #882)

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -756,8 +756,20 @@ export default {
       throw new Error('Rendered items limit reached')
     },
 
+    isAnyVisibleGap () {
+      // Check if any view index is not in sequence (detect gaps)
+      return this.pool
+        .filter(({ nr }) => nr.used)
+        .every(({ nr }, i) => i === 0 || nr.index !== this.pool[i - 1].index + 1)
+    },
+
     sortViews () {
       this.pool.sort((viewA, viewB) => viewA.nr.index - viewB.nr.index)
+
+      if(this.isAnyVisibleGap()) {
+        this.updateVisibleItems()
+        clearTimeout(this.$_sortTimer)
+      }
     },
   },
 }


### PR DESCRIPTION
Hi, this is an important fix to the latest pre-release as it updates the items after detecting the uncomfortable gaps that appear after scrolling fast (up and down quickly) with the scrollbar. 

This issue can be easily seen when using the mouse or mouse pad and move the scrollbar up and down very quickly with a large list.

Hope you find time to review it.

Thank you for your time