### PR TITLE
fix: update when the items changes, fix #866

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -249,6 +249,10 @@ export default {
       this.updateVisibleItems(true)
     },
 
+    'items.length' () {
+      this.updateVisibleItems(true)
+    },
+
     pageMode () {
       this.applyPageMode()
       this.updateVisibleItems(false)


### PR DESCRIPTION
I noticed that when the items are updated, the corresponding watch is not triggered, which leads to the internal pool not being updated.