### PR TITLE
feat: add emitUpdate prop and update event to DynamicScroller"

### DIFF
--- a/packages/vue-virtual-scroller/src/components/DynamicScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/DynamicScroller.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ItemWithSize, ScrollDirection } from '../types'
+import type { ItemWithSize, ScrollDirection, UpdateCallback, UpdateEventArgs } from '../types'
 import { computed, ref } from 'vue'
 import { useDynamicScroller } from '../composables/useDynamicScroller'
 import RecycleScroller from './RecycleScroller.vue'
@@ -27,7 +27,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  update: [startIndex: number, endIndex: number, visibleStartIndex: number, visibleEndIndex: number]
+  update: UpdateEventArgs
   resize: []
   visible: []
 }>()
@@ -66,9 +66,7 @@ function getDefaultSlotBindings(itemWithSize: unknown, index: number, active: bo
   }
 }
 
-function handleUpdate(startIndex: number, endIndex: number, visibleStartIndex: number, visibleEndIndex: number) {
-  emit('update', startIndex, endIndex, visibleStartIndex, visibleEndIndex)
-}
+const handleUpdate: UpdateCallback = (...args) => emit('update', ...args)
 
 // Expose
 defineExpose({

--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ScrollDirection } from '../types'
+import type { ScrollDirection, UpdateEventArgs } from '../types'
 import { ref } from 'vue'
 import { useRecycleScroller } from '../composables/useRecycleScroller'
 import { ObserveVisibility } from '../directives/observeVisibility'
@@ -53,7 +53,7 @@ const emit = defineEmits<{
   'resize': []
   'visible': []
   'hidden': []
-  'update': [startIndex: number, endIndex: number, visibleStartIndex: number, visibleEndIndex: number]
+  'update': UpdateEventArgs
   'scroll-start': []
   'scroll-end': []
 }>()

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref } from 'vue'
-import type { ScrollDirection, ScrollState, Sizes, View, ViewNonReactive } from '../types'
+import type { ScrollDirection, ScrollState, Sizes, UpdateCallback, View, ViewNonReactive } from '../types'
 import { computed, markRaw, nextTick, onActivated, onBeforeUnmount, onMounted, ref, shallowReactive, toValue, watch } from 'vue'
 import config from '../config'
 import { getScrollParent } from '../scrollparent'
@@ -49,7 +49,7 @@ export function useRecycleScroller(
     onResize?: () => void
     onVisible?: () => void
     onHidden?: () => void
-    onUpdate?: (startIndex: number, endIndex: number, visibleStartIndex: number, visibleEndIndex: number) => void
+    onUpdate?: UpdateCallback
   },
 ): UseRecycleScrollerReturn {
   // Reactive state

--- a/packages/vue-virtual-scroller/src/types.ts
+++ b/packages/vue-virtual-scroller/src/types.ts
@@ -46,3 +46,6 @@ export interface PluginOptions {
   installComponents?: boolean
   componentsPrefix?: string
 }
+
+export type UpdateEventArgs = [startIndex: number, endIndex: number, visibleStartIndex: number, visibleEndIndex: number]
+export type UpdateCallback = (...args: UpdateEventArgs) => void


### PR DESCRIPTION
This PR adds the props emitUpdate and skipHover to `DynamicScroller.vue` and pass them to `RecycleScroller`.

DynamicScroller will also take the update event and re-emit it.

Edit: I have adjusted my PR to Vue 3 and added better types for the update event so it can be used in both DynamicScroller and RecycleScroller