### PR TITLE
Use correct index path in isAnyVisibleGap method

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -745,7 +745,7 @@ export default {
       // Check if any view index is not in sequence (detect gaps)
       return this.pool
         .filter(({ nr }) => nr.used)
-        .every(({ nr }, i) => i === 0 || nr.index !== this.pool[i - 1].index + 1)
+        .some(({ nr }, i, arr) => i > 0 && nr.index !== arr[i - 1].nr.index + 1)
     },
 
     sortViews () {


### PR DESCRIPTION
Pools are arrays of Views. Views don't have an index property directly. They have it under the nr object. 