### PR TITLE
feat: add reuseByKey prop for incremental view recycling

### DIFF
--- a/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
+++ b/packages/vue-virtual-scroller/src/components/RecycleScroller.vue
@@ -27,6 +27,7 @@ const props = withDefaults(defineProps<{
   skipHover?: boolean
   listClass?: string | Record<string, boolean> | Array<string | Record<string, boolean>>
   itemClass?: string | Record<string, boolean> | Array<string | Record<string, boolean>>
+  reuseByKey?: boolean
 }>(), {
   keyField: 'id',
   direction: 'vertical',
@@ -47,6 +48,7 @@ const props = withDefaults(defineProps<{
   skipHover: false,
   listClass: '',
   itemClass: '',
+  reuseByKey: false,
 })
 
 const emit = defineEmits<{

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -20,6 +20,7 @@ export interface UseRecycleScrollerOptions {
   prerender: number
   emitUpdate: boolean
   updateInterval: number
+  reuseByKey: boolean
 }
 
 export interface UseRecycleScrollerReturn {
@@ -441,6 +442,20 @@ export function useRecycleScroller(
           }
         }
       }
+
+      // reuseByKey mode: clean up views whose keys no longer exist in the current items
+      if (toValue(options).reuseByKey) {
+        const newKeys = new Set<string | number>()
+        for (let i = startIndex; i < endIndex; i++) {
+          const k = keyField ? (items[i] as any)[keyField] : i
+          newKeys.add(k)
+        }
+        for (const [key, v] of views) {
+          if (!newKeys.has(key)) {
+            removeAndRecycleView(v)
+          }
+        }
+      }
     }
 
     // Step 2: Assign a view and update props for every view that became visible
@@ -612,7 +627,7 @@ export function useRecycleScroller(
 
   // Watchers
   watch(() => toValue(options).items, () => {
-    updateVisibleItems(true)
+    updateVisibleItems(!toValue(options).reuseByKey)
   })
 
   watch(() => toValue(options).pageMode, () => {


### PR DESCRIPTION
## Motivation

When rendering stateful child components (e.g. playing videos, expanded accordions, editing forms) inside `RecycleScroller`, any change to the `items` array reference — even filtering out a single item — causes **all views to be fully recycled and randomly reassigned**. This destroys all child component internal state.

```vue
<RecycleScroller :items="filteredItems" key-field="id">
  <template #default="{ item }">
    <StatefulCard :data="item" />
  </template>
</RecycleScroller>
```

**Root cause:** the `items` watcher always calls `updateVisibleItems(true)`, which triggers `removeAndRecycleAllViews()` — clearing the `_views` Map entirely. On reassignment, `_views.get(key)` always misses, and `getRecycledView()` pops from the pool in LIFO order with no key matching, resulting in views being misassigned to different items.

## Solution

Add a new **`reuse-by-key`** prop that switches the items-change strategy from full recycling to **key-based incremental reuse**:

| `reuse-by-key` | items change behavior |
|---|---|
| `false` (default) | Full recycle & rebuild — original behavior, no breaking changes |
| `true` | Preserve `_views` Map, match views by key precisely |

When enabled:
- **Same key still in items** → view reused as-is, child component state preserved
- **New key not in `_views`** → pulled from recycled pool or created fresh
- **Old key removed from items** → view recycled back to pool

The implementation is minimal because the codebase already has a working incremental path (`continuous && !itemsChanged`). We simply route `items` changes through that path when `reuse-by-key` is enabled, and add a cleanup step to recycle stale keys.

## Usage

### Basic — Filtering / incremental changes

```vue
<RecycleScroller
  :items="filteredItems"
  key-field="id"
  reuse-by-key
>
  <template #default="{ item }">
    <StatefulCard :data="item" />
  </template>
</RecycleScroller>
```

### Dynamic add/remove — Preserving sibling state

When items are dynamically added or removed (e.g. a todo list, a chat message list, or a real-time dashboard), the remaining items' child components should keep their internal state untouched:

```vue
<script setup>
import { ref } from 'vue'

const items = ref([
  { id: 1, text: 'Item A' },
  { id: 2, text: 'Item B' },
  { id: 3, text: 'Item C' },
])

function addItem() {
  const newId = Date.now()
  items.value = [...items.value, { id: newId, text: `Item ${newId}` }]
}

function removeItem(id: number) {
  items.value = items.value.filter(item => item.id !== id)
}
</script>

<template>
  <button @click="addItem">Add Item</button>

  <RecycleScroller
    :items="items"
    :item-size="60"
    key-field="id"
    reuse-by-key
  >
    <template #default="{ item }">
      <!--
        StatefulCard holds internal state (e.g. expanded/collapsed,
        playing progress, draft text). Without reuse-by-key, removing
        any single item would cause ALL siblings to lose their state.
      -->
      <StatefulCard :data="item" @remove="removeItem(item.id)" />
    </template>
  </RecycleScroller>
</template>
```

Without `reuse-by-key`: removing item B causes item A and C's views to be recycled and randomly reassigned — their internal state (expanded accordion, playing video, editing draft) is lost.

With `reuse-by-key`: only item B's view is recycled to the pool. Item A and C's views are matched by key and stay in place — their child component state is fully preserved.

### Full rebuild via Vue `:key`

When the data source changes semantically (e.g. switching to an entirely different dataset where key meanings differ), use Vue's `:key` to destroy and recreate the entire scroller:

```vue
<RecycleScroller
  :key="scrollerEpoch"
  :items="filteredItems"
  key-field="id"
  reuse-by-key
>
  <!-- ... -->
</RecycleScroller>
```

```ts
const scrollerEpoch = ref(0)

function switchDataSource(newSource: DataSource) {
  currentSource.value = newSource
  scrollerEpoch.value++ // force full rebuild
}
```

| Scenario | Increment epoch? | Reason |
|---|---|---|
| Filter keyword changes (subset) | ❌ | Key semantics unchanged, `reuse-by-key` handles it |
| Add/remove individual items | ❌ | Incremental update |
| Switch to a completely different dataset | ✅ | Key semantics changed |

## Changes

- **`useRecycleScroller.ts`**
  - Add `reuseByKey: boolean` to `UseRecycleScrollerOptions` interface
  - Items watcher: `updateVisibleItems(true)` → `updateVisibleItems(!opts.reuseByKey)`
  - Incremental recycling path: add stale key cleanup when `reuseByKey` is enabled
- **`RecycleScroller.vue`**
  - Add `reuse-by-key` prop (default: `false`)
- **`DynamicScroller.vue`**
  - No changes needed — `reuse-by-key` is automatically passed through via `v-bind="$attrs"`
