### PR TITLE
fix: correct viewport calculation in pageMode when scroll container is not window

### DIFF
--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -233,10 +233,10 @@ export function useRecycleScroller(
       // cases where the scroll container is not the document itself
       const scroller = getListenerTarget()
       const isWindow = scroller === window
-      const scrollerBounds = isWindow ? { top: 0, left: 0, bottom: window.innerHeight, right: window.innerWidth } : (scroller as Element).getBoundingClientRect()
-      const viewportSize = isVertical
-        ? (isWindow ? window.innerHeight : scrollerBounds.bottom - scrollerBounds.top)
-        : (isWindow ? window.innerWidth : scrollerBounds.right - scrollerBounds.left)
+      const scrollerBounds = isWindow
+        ? { top: 0, left: 0, height: window.innerHeight, width: window.innerWidth }
+        : (scroller as Element).getBoundingClientRect()
+      const viewportSize = isVertical ? scrollerBounds.height : scrollerBounds.width
       // Position of the list in the scroll container's coordinate system
       const listStart = isVertical ? bounds.top - scrollerBounds.top : bounds.left - scrollerBounds.left
       // Compute the intersection of the viewport and the list (relative to the list itself)

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -229,30 +229,52 @@ export function useRecycleScroller(
     if (opts.pageMode) {
       const bounds = elValue.getBoundingClientRect()
       const boundsSize = isVertical ? bounds.height : bounds.width
-      let start = -(isVertical ? bounds.top : bounds.left)
-      let size = isVertical ? window.innerHeight : window.innerWidth
-      if (start < 0) {
-        size += start
-        start = 0
+      // In pageMode, calculate position relative to the scroll container to handle
+      // cases where the scroll container is not the document itself
+      const scroller = getListenerTarget()
+      const isWindow = scroller === window
+      const scrollerBounds = isWindow ? { top: 0, left: 0, bottom: window.innerHeight, right: window.innerWidth } : (scroller as Element).getBoundingClientRect()
+      const viewportSize = isVertical
+        ? (isWindow ? window.innerHeight : scrollerBounds.bottom - scrollerBounds.top)
+        : (isWindow ? window.innerWidth : scrollerBounds.right - scrollerBounds.left)
+      // Position of the list in the scroll container's coordinate system
+      const listStart = isVertical ? bounds.top - scrollerBounds.top : bounds.left - scrollerBounds.left
+      // Compute the intersection of the viewport and the list (relative to the list itself)
+      // viewportStart/viewportEnd are the scroll container's visible area relative to itself (0 ~ viewportSize)
+      const viewportStart = 0
+      const viewportEnd = viewportSize
+
+      // Convert the viewport range to list-relative coordinates
+      // start: position of the first visible pixel in the list
+      // end: position of the last visible pixel in the list
+      const start = Math.max(0, viewportStart - listStart)
+      let end = Math.min(boundsSize, viewportEnd - listStart)
+      // Ensure end >= start
+      if (end < start) {
+        end = start
       }
-      if (start + size > boundsSize) {
-        size = boundsSize - start
-      }
+      // Get the actual scroll position of the container, used to determine if an update is needed
+      const scrollPosition = isWindow
+        ? (isVertical ? window.pageYOffset || document.documentElement.scrollTop : window.pageXOffset || document.documentElement.scrollLeft)
+        : (isVertical ? (scroller as Element).scrollTop : (scroller as Element).scrollLeft)
       scrollState = {
         start,
-        end: start + size,
+        end,
+        scrollPosition,
       }
     }
     else if (isVertical) {
       scrollState = {
         start: elValue.scrollTop,
         end: elValue.scrollTop + elValue.clientHeight,
+        scrollPosition: elValue.scrollTop,
       }
     }
     else {
       scrollState = {
         start: elValue.scrollLeft,
         end: elValue.scrollLeft + elValue.clientWidth,
+        scrollPosition: elValue.scrollLeft,
       }
     }
 
@@ -318,7 +340,7 @@ export function useRecycleScroller(
 
       // Skip update if user hasn't scrolled enough
       if (checkPositionDiff) {
-        let positionDiff = scroll.start - _lastUpdateScrollPosition
+        let positionDiff = scroll.scrollPosition - _lastUpdateScrollPosition
         if (positionDiff < 0)
           positionDiff = -positionDiff
         if ((itemSize === null && positionDiff < minItemSize) || (itemSize !== null && positionDiff < itemSize)) {
@@ -327,7 +349,7 @@ export function useRecycleScroller(
           }
         }
       }
-      _lastUpdateScrollPosition = scroll.start
+      _lastUpdateScrollPosition = scroll.scrollPosition
 
       const buffer = opts.buffer
       scroll.start -= buffer

--- a/packages/vue-virtual-scroller/src/types.ts
+++ b/packages/vue-virtual-scroller/src/types.ts
@@ -3,6 +3,7 @@ export type ScrollDirection = 'vertical' | 'horizontal'
 export interface ScrollState {
   start: number
   end: number
+  scrollPosition: number
 }
 
 export interface ViewNonReactive {


### PR DESCRIPTION
### Problem

When using `RecycleScroller` with `pageMode` enabled, the visible area calculation assumes the scroll container is always `window`. However, in real-world scenarios, there can be an **intermediate scroll container** between the document and the virtual scroller element (e.g., a parent `<div>` with `overflow: auto`).

In such cases, the original implementation computes `start` using `-(bounds.top)` and `size` using `window.innerHeight`, which are relative to the browser viewport rather than the actual scroll container. This leads to:

1. **Incorrect visible range**: The scroller renders items based on the wrong viewport, causing blank areas or rendering items that are not actually visible.
2. **Inaccurate scroll throttling**: The position diff check uses `scroll.start` (a viewport-relative offset), which changes inconsistently when the scroll container is not `window`, leading to unnecessary skipped updates or excessive re-renders.

### Solution

**1. Viewport-aware scroll calculation (`getScroll`)**

Instead of always using `window.innerHeight` and `bounds.top`, the new implementation:
- Retrieves the actual scroll container via `getListenerTarget()`
- Calculates the list's position relative to the scroll container's coordinate system
- Computes the intersection of the scroll container's visible area and the list bounds
- This correctly handles both `window` scrolling and non-window scroll containers

**2. Separate `scrollPosition` from `start`/`end` (`ScrollState`)**

Added a `scrollPosition` field to `ScrollState`:
- `start`/`end`: represent the visible portion of the list in list-relative coordinates (used for index calculation)
- `scrollPosition`: represents the actual scroll offset of the container (used for scroll throttling)

In non-pageMode, `scrollPosition` equals `start`, so there is **no behavioral change** for existing non-pageMode usage.

### Changed Files

- `packages/vue-virtual-scroller/src/types.ts` — Added `scrollPosition` to `ScrollState` interface
- `packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts` — Rewrote pageMode branch in `getScroll()`, added `scrollPosition` to all branches, updated position diff check in `updateVisibleItems()`
