### PR TITLE
fix: release stale pooled views when items array shrinks

### DIFF
--- a/packages/vue-virtual-scroller/src/composables/useDynamicScroller.spec.ts
+++ b/packages/vue-virtual-scroller/src/composables/useDynamicScroller.spec.ts
@@ -605,6 +605,29 @@ describe('useDynamicScroller', () => {
     expect(vm.visiblePool.map((view: any) => view.index)).toEqual([0])
   })
 
+  it('does not leave a stale used view after filtering a 2-item list down to 1 (variable size, no flow-mode)', async () => {
+    // Variable-height DynamicScroller (numeric minItemSize, no flowMode) with
+    // key-field=id. When the items array shrinks from [A, B] to [A], the
+    // dropped view must be released — otherwise the pool keeps both views
+    // `used: true` and the DOM still renders two rows.
+    const { vm, options } = mountHarness([
+      { id: 'A' },
+      { id: 'B' },
+    ])
+
+    await nextTick()
+    await nextTick()
+
+    options.items = [{ id: 'A' }]
+    await nextTick()
+    await nextTick()
+
+    const usedKeys = vm.pool
+      .filter((view: any) => view.used)
+      .map((view: any) => view.key)
+    expect(usedKeys).toEqual(['A'])
+  })
+
   it('adjusts scroll position when measured sizes change above the viewport', async () => {
     const { vm, el } = mountHarness([
       { id: 'a', label: 'Alpha' },

--- a/packages/vue-virtual-scroller/src/composables/useDynamicScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useDynamicScroller.ts
@@ -698,7 +698,12 @@ export function useDynamicScroller<TOptions extends UseDynamicScrollerOptions<an
     if (changed) {
       _pendingViewportAnchor = viewportAnchor
       itemsWithSizeVersion.value++
-      triggerRef(itemsWithSize)
+      // Assign a new array reference rather than relying on triggerRef alone.
+      // Downstream consumers (e.g. <RecycleScroller>'s `props.items` via toRef)
+      // compare prop references with Object.is — an in-place mutation that keeps
+      // the same reference is invisible to prop reactivity, so their items
+      // watcher never fires on shrink.
+      itemsWithSize.value = _itemsWithSizeEntries.slice()
     }
   })
 

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.spec.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.spec.ts
@@ -990,6 +990,29 @@ describe('useRecycleScroller', () => {
     expect(vm.visiblePool.map((view: View) => view.nr.index)).toEqual([0])
   })
 
+  it('does not leave a stale used view after filtering a 2-item list down to 1 (variable size, no flow-mode)', async () => {
+    // Variable-height pool (minItemSize set, no flowMode). When the items
+    // array shrinks from [A, B] to [A], the dropped view must be released —
+    // otherwise the pool keeps both views `used: true` and the DOM still
+    // renders two rows.
+    const { vm, options } = mountHarness({
+      items: [{ id: 'A' }, { id: 'B' }],
+      itemSize: null,
+      minItemSize: 40,
+      clientHeight: 400,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    options.items = [{ id: 'A' }]
+    await nextTick()
+    await nextTick()
+
+    const usedViews = vm.pool.filter((view: View) => view.nr.used)
+    expect(usedViews.map((view: View) => view.nr.key)).toEqual(['A'])
+  })
+
   it('recomputes visiblePool when a view is manually flipped to unused', async () => {
     // Regression: `view.nr` is markRaw, so `visiblePool`'s `.filter(view => view.nr.used)`
     // establishes no reactive dep on `.used`. Without tracking `_vs_visibilityStamp`,

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -62,7 +62,7 @@ export interface UseRecycleScrollerReturn<TItem = unknown, TKey = ItemKey<TItem>
   sortViews: () => void
 }
 
-type ViewWithStyleStamp<TItem = unknown, TKey = ItemKey<TItem>> = View<TItem, TKey> & {
+export type ViewWithStyleStamp<TItem = unknown, TKey = ItemKey<TItem>> = View<TItem, TKey> & {
   _vs_styleStamp: number
   _vs_visibilityStamp: number
 }

--- a/packages/vue-virtual-scroller/src/utils/viewStyle.spec.ts
+++ b/packages/vue-virtual-scroller/src/utils/viewStyle.spec.ts
@@ -1,0 +1,57 @@
+import type { ViewWithStyleStamp } from '../composables/useRecycleScroller'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, markRaw, nextTick, shallowReactive } from 'vue'
+import { getPooledViewStyle } from './viewStyle'
+
+function createTestView(used: boolean): ViewWithStyleStamp {
+  return shallowReactive({
+    item: { id: 'A' },
+    position: 0,
+    offset: 0,
+    _vs_styleStamp: 0,
+    _vs_visibilityStamp: 0,
+    nr: markRaw({
+      id: 1,
+      index: 0,
+      used,
+      key: 'A',
+      type: 'default',
+    }),
+  }) as unknown as ViewWithStyleStamp
+}
+
+describe('getPooledViewStyle reactivity', () => {
+  it('updates the rendered visibility style when nr.used flips and the visibility stamp is bumped', async () => {
+    // `view.nr` is markRaw, so reading `view.nr.used` inside a render context
+    // establishes no reactive dep. Without anchoring on the visibility stamp,
+    // flipping `used` would not re-evaluate the inline style and parked rows
+    // would keep `visibility: visible`.
+    const view = createTestView(true)
+
+    const Harness = defineComponent({
+      setup() {
+        return () =>
+          h('div', {
+            'data-testid': 'pooled',
+            'style': getPooledViewStyle(view, { direction: 'vertical', mode: 'transform' }),
+          })
+      },
+    })
+
+    const wrapper = mount(Harness)
+    await nextTick()
+
+    const el = wrapper.get('[data-testid="pooled"]').element as HTMLElement
+    expect(el.style.visibility).toBe('visible')
+
+    // Mimic the recycler flipping the view to unused: the composable mutates
+    // `nr.used` and bumps `_vs_visibilityStamp` on the shallow-reactive view.
+    view.nr.used = false
+    view._vs_visibilityStamp++
+
+    await nextTick()
+
+    expect(el.style.visibility).toBe('hidden')
+  })
+})

--- a/packages/vue-virtual-scroller/src/utils/viewStyle.ts
+++ b/packages/vue-virtual-scroller/src/utils/viewStyle.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'vue'
+import type { ViewWithStyleStamp } from '../composables/useRecycleScroller'
 import type { ScrollDirection, View } from '../types'
 
 /**
@@ -35,11 +36,17 @@ export function resolvePooledViewMode(options: {
 
 /**
  * Build deterministic inline styles for a pooled view.
+ *
+ * Reactivity note: `view.nr` is `markRaw`, so reads of `view.nr.used` create
+ * no reactive dep when this is called inside a Vue render context. Read
+ * `_vs_visibilityStamp` first — it is bumped via `touchViewVisibility`
+ * whenever `used` flips, anchoring reactivity so the style binding refreshes.
  */
 export function getPooledViewStyle<TItem, TKey>(
   view: View<TItem, TKey>,
   options: PooledViewStyleOptions,
 ): CSSProperties {
+  void (view as ViewWithStyleStamp<TItem, TKey>)._vs_visibilityStamp
   const isVertical = options.direction === 'vertical'
   const mode = options.mode ?? 'transform'
   const style: CSSProperties = {


### PR DESCRIPTION
## Summary

Two reactivity gaps caused filtered-out rows in `DynamicScroller` / `RecycleScroller` to keep rendering as `used: true`. Reproducer: a 2-item list filtered down to 1 still renders both rows in the DOM.

### Root causes

1. **`useDynamicScroller`**: the watcher mutated `_itemsWithSizeEntries` in place and called `triggerRef(itemsWithSize)`. Downstream consumers (`RecycleScroller`'s `props.items` via `toRef`) compare prop references with `Object.is`, so a same-reference mutation is invisible to prop reactivity and the items watcher never fires on shrink. Fix: assign a fresh `_itemsWithSizeEntries.slice()` to `itemsWithSize.value`.

2. **`viewStyle.getPooledViewStyle`**: reads `view.nr.used`, but `nr` is `markRaw`, so reads in a render context establish no reactive dep. When `used` flips, the inline style never re-evaluates and the row keeps `visibility: visible`. Fix: read `_vs_visibilityStamp` first to anchor reactivity — same pattern already used in `visiblePool` at `useRecycleScroller.ts:365`.

### Tests

Added regression tests covering the filter-shrink scenario:
- `useDynamicScroller.spec.ts` — pool releases the dropped view
- `useRecycleScroller.spec.ts` — pool releases the dropped view
- `viewStyle.spec.ts` — `getPooledViewStyle` re-evaluates when `_vs_visibilityStamp` is bumped

### Speed implications

The slice replaces an O(1) `triggerRef` with an O(n) shallow copy of entry pointers, gated by `if (changed)` — it only runs when the entry composition actually shifts (filter, replace, add, remove), not on every render, scroll tick, or size remeasurement.

Microbench on Apple Silicon / Node 25 (`arr.slice()` on packed entry-shaped arrays):

| n | median |
|---|---|
| 1,000 | 0.21µs |
| 10,000 | 1.37µs |
| 100,000 | 80µs |
| 1,000,000 | 808µs |

V8 dispatches packed-array `slice` to a near-`memcpy` path. For realistic scroller list sizes the copy is sub-microsecond and runs alongside the pool diff / view rebind / layout pipeline that already dominates an items-prop change. No hot-path regression expected.

### Drive-by

- Exported `ViewWithStyleStamp` type from `useRecycleScroller` so `viewStyle.ts` and its spec can reuse the established type instead of an ad-hoc inline cast.

## Test plan

- [x] `pnpm -C packages/vue-virtual-scroller test` — 140/140 pass
- [x] `pnpm -C packages/vue-virtual-scroller typecheck` — clean
- [x] `pnpm exec eslint` on changed files — clean
- [ ] Maintainer review of the reactivity reasoning (`Object.is` prop-identity, `markRaw` dep tracking)