### PR TITLE
fix: recycle stale views when key/type identity diverges

### DIFF
--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.spec.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.spec.ts
@@ -1208,4 +1208,201 @@ describe('useRecycleScroller enabled option', () => {
     expect(result).toEqual({ continuous: true })
     expect((wrapper.vm as any).pool.length).toBe(0)
   })
+
+  it('recycles stale views when updateVisibleItems(false) is called after items swap at overlapping indices', async () => {
+    // Reproduces the DynamicScroller race: when the sizes watcher fires before
+    // the items-identity watcher, updateVisibleItems runs with itemsChanged=false.
+    // Views from the old list whose index is still in the visible range AND
+    // whose size slot is valid (populated by the new item at that index) survived
+    // the Step 1 recycling check — even though their key belonged to the OLD item.
+    // This caused duplicate visible views and overlapping positions.
+    const { vm, options } = mountHarness({
+      items: [
+        { id: 'a', size: 20 },
+        { id: 'b', size: 30 },
+        { id: 'c', size: 25 },
+        { id: 'd', size: 35 },
+        { id: 'e', size: 20 },
+      ],
+      itemSize: null,
+      minItemSize: 10,
+      sizeField: 'size',
+      clientHeight: 200,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(vm.visiblePool.length).toBe(5)
+
+    // Directly swap items and call updateVisibleItems(false) BEFORE the items
+    // watcher fires — this is the exact race condition that occurs when the
+    // sizes watcher fires ahead of the items-identity watcher.
+    options.items = [
+      { id: 'c', size: 25 },
+      { id: 'a', size: 20 },
+      { id: 'e', size: 20 },
+    ]
+
+    // Simulate the sizes watcher: call updateVisibleItems WITHOUT itemsChanged
+    vm.updateVisibleItems(false)
+
+    // After this call, no two used views should share the same key,
+    // and no view should have a key that doesn't match its item's key
+    const usedViews = vm.pool.filter((v: View) => v.nr.used)
+    const usedKeys = usedViews.map((v: View) => v.nr.key)
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+
+    // Every used view's key must match the item at its index
+    for (const v of usedViews) {
+      const expectedId = (options.items[v.nr.index] as { id: string }).id
+      expect(v.nr.key).toBe(expectedId)
+    }
+  })
+
+  it('recycles stale views in fixed-size mode when updateVisibleItems(false) is called after items swap', async () => {
+    const { vm, options } = mountHarness({
+      items: [
+        { id: 'x' },
+        { id: 'y' },
+        { id: 'z' },
+        { id: 'w' },
+      ],
+      itemSize: 10,
+      clientHeight: 100,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(vm.visiblePool.map((v: View) => v.nr.key)).toEqual(['x', 'y', 'z', 'w'])
+
+    // Swap items — keys at indices 0-2 change
+    options.items = [
+      { id: 'z' },
+      { id: 'x' },
+      { id: 'w' },
+    ]
+
+    // Simulate sizes watcher race
+    vm.updateVisibleItems(false)
+
+    const usedViews = vm.pool.filter((v: View) => v.nr.used)
+    const usedKeys = usedViews.map((v: View) => v.nr.key)
+
+    // No duplicate keys among used views
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+
+    // Every used view's key must match its item
+    for (const v of usedViews) {
+      const expectedId = (options.items[v.nr.index] as { id: string }).id
+      expect(v.nr.key).toBe(expectedId)
+    }
+  })
+
+  it('handles rapid swaps without stale views accumulating via sizes watcher race', async () => {
+    const { vm, options } = mountHarness({
+      items: [
+        { id: '1', size: 20 },
+        { id: '2', size: 20 },
+        { id: '3', size: 15 },
+        { id: '4', size: 25 },
+        { id: '5', size: 20 },
+      ],
+      itemSize: null,
+      minItemSize: 10,
+      sizeField: 'size',
+      clientHeight: 200,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    // Swap 1: simulate sizes watcher race
+    options.items = [
+      { id: '3', size: 15 },
+      { id: '1', size: 20 },
+      { id: '5', size: 20 },
+    ]
+    vm.updateVisibleItems(false)
+
+    let usedViews = vm.pool.filter((v: View) => v.nr.used)
+    let usedKeys = usedViews.map((v: View) => v.nr.key)
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+
+    // Now let the items watcher catch up
+    await nextTick()
+    await nextTick()
+
+    // Swap 2: back to full list, then sizes race again
+    options.items = [
+      { id: '1', size: 20 },
+      { id: '2', size: 20 },
+      { id: '3', size: 15 },
+      { id: '4', size: 25 },
+      { id: '5', size: 20 },
+    ]
+    vm.updateVisibleItems(false)
+
+    usedViews = vm.pool.filter((v: View) => v.nr.used)
+    usedKeys = usedViews.map((v: View) => v.nr.key)
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+
+    await nextTick()
+    await nextTick()
+
+    // Swap 3: down to 2
+    options.items = [
+      { id: '2', size: 20 },
+      { id: '4', size: 25 },
+    ]
+    vm.updateVisibleItems(false)
+
+    usedViews = vm.pool.filter((v: View) => v.nr.used)
+    usedKeys = usedViews.map((v: View) => v.nr.key)
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+  })
+
+  it('recycles views whose type changed at the same index during sizes watcher race', async () => {
+    // When an item keeps the same key but changes typeField during the race,
+    // the view must be recycled so it enters the correct type bucket.
+    const { vm, options } = mountHarness({
+      items: [
+        { id: 'a', type: 'alpha', size: 20 },
+        { id: 'b', type: 'beta', size: 30 },
+      ],
+      itemSize: null,
+      minItemSize: 10,
+      sizeField: 'size',
+      clientHeight: 200,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(vm.visiblePool.length).toBe(2)
+    expect(vm.visiblePool.map((v: View) => v.nr.type)).toEqual(['alpha', 'beta'])
+
+    // Same keys, same order, but types swapped
+    options.items = [
+      { id: 'a', type: 'beta', size: 20 },
+      { id: 'b', type: 'alpha', size: 30 },
+    ]
+
+    vm.updateVisibleItems(false)
+
+    const usedViews = vm.pool.filter((v: View) => v.nr.used)
+    const usedKeys = usedViews.map((v: View) => v.nr.key)
+    expect(new Set(usedKeys).size).toBe(usedKeys.length)
+
+    // After the items watcher catches up, types must match
+    await nextTick()
+    await nextTick()
+
+    const finalViews = vm.pool.filter((v: View) => v.nr.used)
+    for (const v of finalViews) {
+      const item = options.items[v.nr.index] as { id: string, type: string }
+      expect(v.nr.key).toBe(item.id)
+    }
+  })
 })

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -1376,11 +1376,30 @@ export function useRecycleScroller<TOptions extends UseRecycleScrollerOptions<an
         }
         view = currentView
         if (view.nr.used) {
+          const viewIndex = view.nr.index
           const viewVisible = renderedIndexSet
-            ? renderedIndexSet.has(view.nr.index)
-            : (view.nr.index >= startIndex && view.nr.index < endIndex)
-          const viewSize = itemSize || (sizesValue[view.nr.index] && sizesValue[view.nr.index].size)
-          if (!viewVisible || !viewSize) {
+            ? renderedIndexSet.has(viewIndex)
+            : (viewIndex >= startIndex && viewIndex < endIndex)
+          const viewSize = itemSize || (sizesValue[viewIndex] && sizesValue[viewIndex].size)
+
+          // Guard against stale views: when a reactive size update fires before
+          // the items-identity watcher, the pool still holds views keyed to the
+          // previous item list. A view whose key or type no longer matches the
+          // item at its index must be recycled even if the index is in the
+          // visible range. This mirrors the key+type identity check used by the
+          // items watcher (hasSameItemIdentitySequence).
+          let viewStale = false
+          if (viewVisible && viewSize && viewIndex < count) {
+            const expectedKey = (keyField
+              ? resolveItemKey(currentItems[viewIndex], viewIndex, keyField)
+              : viewIndex) as ItemKey<TItem, TKeyField>
+            const expectedType = (currentItems[viewIndex] as any)[typeField]
+            if (view.nr.key !== expectedKey || view.nr.type !== expectedType) {
+              viewStale = true
+            }
+          }
+
+          if (!viewVisible || !viewSize || viewStale) {
             removeAndRecycleView(view, keepFlowModeOrderIncrementally)
           }
         }

--- a/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
+++ b/packages/vue-virtual-scroller/src/composables/useRecycleScroller.ts
@@ -1393,7 +1393,7 @@ export function useRecycleScroller<TOptions extends UseRecycleScrollerOptions<an
             const expectedKey = (keyField
               ? resolveItemKey(currentItems[viewIndex], viewIndex, keyField)
               : viewIndex) as ItemKey<TItem, TKeyField>
-            const expectedType = (currentItems[viewIndex] as any)[typeField]
+            const expectedType = getItemType(currentItems[viewIndex], typeField)
             if (view.nr.key !== expectedKey || view.nr.type !== expectedType) {
               viewStale = true
             }


### PR DESCRIPTION
When `DynamicScroller`'s sizes watcher fires before the items-identity watcher, `updateVisibleItems` can run with `itemsChanged=false` and `continuous=true`.

In that path, views from the old list could survive Step 1 recycling if their old index was still visible, even when their `nr.key` or `nr.type` belonged to the previous item at that index. That left stale views in the active pool, causing duplicate rendered rows and overlapping positions.

This adds a key+type identity guard to the continuous scroll Step 1 path: if a view's `nr.key` or `nr.type` no longer matches the item currently at `nr.index`, we mark it stale and recycle it. This mirrors the identity comparison used by `hasSameItemIdentitySequence` in the items watcher.

Behavior before:
<img width="967" height="647" alt="image" src="https://github.com/user-attachments/assets/142a136c-7c8b-47fe-93ac-e6d9a5a485ab" />
Behavior after: 
<img width="966" height="618" alt="image" src="https://github.com/user-attachments/assets/56cc7b2a-1bc8-48b8-8a79-018906b3c838" />

The end user replication involves swapping the list for a smaller list.
 So swapping from 5 items to 3 items triggers the bad behavior.
